### PR TITLE
Fixed to search with equal when searching

### DIFF
--- a/ngx_http_upstream_jvm_route_module.c
+++ b/ngx_http_upstream_jvm_route_module.c
@@ -664,9 +664,8 @@ ngx_http_upstream_jvm_route_get_session_value(ngx_http_request_t *r,
         ngx_pfree(r->pool, keyword);
 
         if (start != NULL) {
-            start++;
-            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "start: \"%s\"", start);
-            start = start + name->len + 1;
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "start: \"%s\"", start + 1);
+            start = start + name->len + 2;
             while (*start != '=') {
                 if (start >= (uri->data + uri->len)) {
                     ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,

--- a/ngx_http_upstream_jvm_route_module.c
+++ b/ngx_http_upstream_jvm_route_module.c
@@ -650,11 +650,11 @@ ngx_http_upstream_jvm_route_get_session_value(ngx_http_request_t *r,
             name = &us->session_cookie;
         }
         u_char *keyword = (u_char *)ngx_palloc(r->pool, name->len + 2);
-        ngx_snprintf(keyword, name->len + 1, "%s=", name->data);
+        ngx_sprintf(keyword, "%V=%Z", name);
 
         uri = &r->unparsed_uri;
 
-        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+        ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                 "[upstream jvm_route] URI: \"%V\", session_name: \"%V\", keyword:\"%s\"", uri, name, keyword);
 
         start = ngx_strncasestrn(uri->data, keyword, uri->len, name->len + 1);

--- a/ngx_http_upstream_jvm_route_module.c
+++ b/ngx_http_upstream_jvm_route_module.c
@@ -659,6 +659,7 @@ ngx_http_upstream_jvm_route_get_session_value(ngx_http_request_t *r,
                 "[upstream jvm_route] URI: \"%V\", session_name: \"%V\", keyword:\"%s\"", uri, name, keyword);
 
         start = ngx_strncasestrn(uri->data, keyword, uri->len, keyword_len);
+        ngx_pfree(r->pool, keyword);
         if (start != NULL) {
             start = start + keyword_len;
             while (*start != '=') {
@@ -684,7 +685,6 @@ ngx_http_upstream_jvm_route_get_session_value(ngx_http_request_t *r,
                 }
             }
         }
-        ngx_pfree(r->pool, keyword);
     }
 
     if (val->len == 0) {

--- a/ngx_http_upstream_jvm_route_module.c
+++ b/ngx_http_upstream_jvm_route_module.c
@@ -664,7 +664,7 @@ ngx_http_upstream_jvm_route_get_session_value(ngx_http_request_t *r,
         ngx_pfree(r->pool, keyword);
 
         if (start != NULL) {
-            start = start + 1;
+            start++;
             ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "start: \"%s\"", start);
             start = start + name->len + 1;
             while (*start != '=') {

--- a/ngx_http_upstream_jvm_route_module.c
+++ b/ngx_http_upstream_jvm_route_module.c
@@ -649,19 +649,18 @@ ngx_http_upstream_jvm_route_get_session_value(ngx_http_request_t *r,
         else {
             name = &us->session_cookie;
         }
-        u_char *keyword = (u_char *)ngx_palloc(r->pool, name->len + 1);
-        ngx_sprintf(keyword, "%s=", name->data);
-        size_t keyword_len = ngx_strlen(keyword);
+        u_char *keyword = (u_char *)ngx_palloc(r->pool, name->len + 2);
+        ngx_snprintf(keyword, name->len + 1, "%s=", name->data);
 
         uri = &r->unparsed_uri;
 
         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                 "[upstream jvm_route] URI: \"%V\", session_name: \"%V\", keyword:\"%s\"", uri, name, keyword);
 
-        start = ngx_strncasestrn(uri->data, keyword, uri->len, keyword_len);
+        start = ngx_strncasestrn(uri->data, keyword, uri->len, name->len + 1);
         ngx_pfree(r->pool, keyword);
         if (start != NULL) {
-            start = start + keyword_len;
+            start = start + name->len + 1;
             while (*start != '=') {
                 if (start >= (uri->data + uri->len)) {
                     ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,

--- a/ngx_http_upstream_jvm_route_module.c
+++ b/ngx_http_upstream_jvm_route_module.c
@@ -665,7 +665,7 @@ ngx_http_upstream_jvm_route_get_session_value(ngx_http_request_t *r,
 
         if (start != NULL) {
             start++;
-            ngx_log_debug3(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "start: \"%s\"", start);
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "start: \"%s\"", start);
             start = start + name->len + 1;
             while (*start != '=') {
                 if (start >= (uri->data + uri->len)) {


### PR DESCRIPTION
If uri contains a session name, an error occurs in the following places.
https://github.com/nulab/nginx-upstream-jvm-route/blob/master/ngx_http_upstream_jvm_route_module.c#L664